### PR TITLE
MODIFY override all the possible versions of PeerConnection

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,15 @@ created inside your library/framework/platform.
         return new origPeerConnection(config, constraints);
     }
 
-    if (origPeerConnection === window.RTCPeerConnection) {
+    if (window.RTCPeerConnection) {
       window.RTCPeerConnection = newPeerConnection;
       window.RTCPeerConnection.prototype = origPeerConnection.prototype;
-    } else if (origPeerConnection === window.webkitRTCPeerConnection) {
+    }
+    if (window.webkitRTCPeerConnection) {
       window.webkitRTCPeerConnection = newPeerConnection;
       window.webkitRTCPeerConnection.prototype = origPeerConnection.prototype;
-    } else if (origPeerConnection === window.mozRTCPeerConnection) {
+    }
+    if (window.mozRTCPeerConnection) {
       window.mozRTCPeerConnection = newPeerConnection;
       window.mozRTCPeerConnection.prototype = origPeerConnection.prototype;
     }

--- a/README.md
+++ b/README.md
@@ -30,18 +30,13 @@ created inside your library/framework/platform.
         return new origPeerConnection(config, constraints);
     }
 
-    if (window.RTCPeerConnection) {
-      window.RTCPeerConnection = newPeerConnection;
-      window.RTCPeerConnection.prototype = origPeerConnection.prototype;
-    }
-    if (window.webkitRTCPeerConnection) {
-      window.webkitRTCPeerConnection = newPeerConnection;
-      window.webkitRTCPeerConnection.prototype = origPeerConnection.prototype;
-    }
-    if (window.mozRTCPeerConnection) {
-      window.mozRTCPeerConnection = newPeerConnection;
-      window.mozRTCPeerConnection.prototype = origPeerConnection.prototype;
-    }
+    ['RTCPeerConnection', 'webkitRTCPeerConnection', 'mozRTCPeerConnection'].forEach(function(obj) {
+        // Override objects if they exist in the window object
+        if (window.hasOwnProperty(obj)) {
+            window[obj] = newPeerConnection;
+            window[obj].prototype =  newPeerConnection.prototype;
+        }
+    });
   }
 })();
 ```


### PR DESCRIPTION
@fippo What do you think of this change?   Shouldn't we always override all the possible representations of the PeerConnection API?

Otherwise if the browser supports RTCPeerConnection but the third party library is using webkitRTCPeerConnection it doesn't work.